### PR TITLE
Update Effekseer+GL.cpp

### DIFF
--- a/Players/Cocos2d-x_v4/EffekseerForCocos2d-x/GL/Effekseer+GL.cpp
+++ b/Players/Cocos2d-x_v4/EffekseerForCocos2d-x/GL/Effekseer+GL.cpp
@@ -77,7 +77,7 @@ bool DistortingCallbackGL::OnDistorting(EffekseerRenderer::Renderer* renderer)
 
 	glBindTexture(GL_TEXTURE_2D, backGroundTexture);
 	//glCopyTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height );
-	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, viewport[0], viewport[1], width, height);
+	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, viewport[0], viewport[1], width, height);//bad performace.(Iphone - OpenGL ES3)
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	auto r = static_cast<EffekseerRendererGL::Renderer*>(renderer);


### PR DESCRIPTION
log: 
glCopyTexSubImage2D()  with a bad performace.(Iphone - OpenGL ES3)
